### PR TITLE
Fix consistency in faq.json

### DIFF
--- a/config/faq.json
+++ b/config/faq.json
@@ -43,28 +43,56 @@
       "https://discordapp.com/channels/154777837382008833/157097006500806656/510121232147152906",
       "https://i.imgur.com/8iKnwnr.png"
     ],
-    "tags": "datapack datapacks data pack packs structure format layout"
+    "tags": "datapack datapacks data pack packs data-pack data-packs structure format layout"
   },
   "data pack structure (light)": {
     "message": [
       "https://discordapp.com/channels/154777837382008833/157097006500806656/510121232147152906",
       "https://cdn.discordapp.com/attachments/295476675351805953/571527194841448478/unknown.png"
     ],
-    "tags": "datapack datapacks data pack packs structure format layout"
+    "tags": "datapack datapacks data pack packs data-pack data-packs structure format layout (light) light"
+  },
+    "datapack structure": {
+    "message": [
+      "https://discordapp.com/channels/154777837382008833/157097006500806656/510121232147152906",
+      "https://i.imgur.com/8iKnwnr.png"
+    ],
+    "tags": "datapack datapacks data pack packs data-pack data-packs structure format layout"
+  },
+  "datapack structure (light)": {
+    "message": [
+      "https://discordapp.com/channels/154777837382008833/157097006500806656/510121232147152906",
+      "https://cdn.discordapp.com/attachments/295476675351805953/571527194841448478/unknown.png"
+    ],
+    "tags": "datapack datapacks data pack packs data-pack data-packs structure format layout (light) light"
   },
   "resource pack structure": {
     "message": [
       "https://discordapp.com/channels/154777837382008833/157097006500806656/510121295287943205",
       "https://i.imgur.com/2Ksb7vj.png"
     ],
-    "tags": "resourcepack resourcepacks resource pack packs structure format layout"
+    "tags": "resourcepack resourcepacks resource pack packs resource-pack resource-packs structure format layout"
   },
   "resource pack structure (light)": {
     "message": [
       "https://discordapp.com/channels/154777837382008833/157097006500806656/510121295287943205",
       "https://cdn.discordapp.com/attachments/295476675351805953/571529824137379841/unknown.png"
     ],
-    "tags": "resourcepack resourcepacks resource pack packs structure format layout"
+    "tags": "resourcepack resourcepacks resource pack packs resource-pack resource-packs structure format layout (light) light"
+  },
+    "resourcepack structure": {
+    "message": [
+      "https://discordapp.com/channels/154777837382008833/157097006500806656/510121295287943205",
+      "https://i.imgur.com/2Ksb7vj.png"
+    ],
+    "tags": "resourcepack resourcepacks resource pack packs resource-pack resource-packs structure format layout"
+  },
+  "resourcepack structure (light)": {
+    "message": [
+      "https://discordapp.com/channels/154777837382008833/157097006500806656/510121295287943205",
+      "https://cdn.discordapp.com/attachments/295476675351805953/571529824137379841/unknown.png"
+    ],
+    "tags": "resourcepack resourcepacks resource pack packs resource-pack resource-packs structure format layout (light) light"
   },
   "player slots": {
     "message": "https://gamepedia.cursecdn.com/minecraft_gamepedia/b/b2/Items_slot_number.png?version=3afad52a1728dd42b02d0bf4b5d5364e",

--- a/config/faq.json
+++ b/config/faq.json
@@ -38,7 +38,7 @@
     ],
     "tags": "game output log gamelog debugging"
   },
-  "datapack structure": {
+  "data pack structure": {
     "message": [
       "https://discordapp.com/channels/154777837382008833/157097006500806656/510121232147152906",
       "https://i.imgur.com/8iKnwnr.png"
@@ -52,7 +52,7 @@
     ],
     "tags": "datapack datapacks data pack packs structure format layout"
   },
-  "resourcepack structure": {
+  "resource pack structure": {
     "message": [
       "https://discordapp.com/channels/154777837382008833/157097006500806656/510121295287943205",
       "https://i.imgur.com/2Ksb7vj.png"


### PR DESCRIPTION
Currently, `resourcepack structure` and `resource pack structure (light)`, as well as `datapack structure` and `data pack structure (light)` are inconsistently named. This pull request fixes that error.

Additionally, new FAQs are added:
 - `resourcepack structure`
 - `datapack structure`
 - `resourcepack structure (light)`
 - `datapack structure (light)`

Finally, the tags `data-pack` and `data-packs` have been added to all variants of `data pack structure`, the tags `resource-pack` and `resource-packs` have been added to all variants of `resource pack structure`, and the tags `light` and `(light)` have been added to all light variants of `resource pack structure` and `data pack structure`.