### PR TITLE
rx: added snek_irl cmd, very important

### DIFF
--- a/config/faq.json
+++ b/config/faq.json
@@ -298,6 +298,9 @@
     ],
     "tags": "disabledslots slots disabled armor_stand armor stand armorstand",
     "aliases": ["dst"]
+  },
+  "snek_irl": {
+    "message": "J no I on red Cross y it",
+    "tags": "snek_irl snek snake snake_irl"
   }
-  
 }


### PR DESCRIPTION
`snek_irl`: `J no I on red Cross y it`

Why? This is very important and **needs** to be in the faq table!