### PR TITLE
Updated link to datapack template

### DIFF
--- a/config/faq.json
+++ b/config/faq.json
@@ -222,7 +222,7 @@
     "tags": "tag json datapack tags groups group tick.json load.json"
   },
   "data pack template": {
-    "message": "<https://discordapp.com/channels/154777837382008833/157097006500806656/512353496897421312>",
+    "message": "<https://discordapp.com/channels/154777837382008833/157097006500806656/672030206848139304>",
     "tags": "datapack data pack template",
     "aliases": ["datapack template", "data-pack template", "dpt"]
   },


### PR DESCRIPTION
The template now contains a `predicates` folder and the `pack_format` is set to 5.