### PR TITLE
Faq submission 

### DIFF
--- a/config/faq.json
+++ b/config/faq.json
@@ -578,5 +578,18 @@
     ],
     "tags": "java entity interpolation",
     "aliases": ["aec air toggling", "remove interpolation", "air toggle", "aec air toggle"]
+  },
+  "submitting faqs": {
+    "message": [
+      "Our faq system is based off of submitting pull requests on github. If you want to submit one, you'll need a github account. You also probably want a basic understanding of how git works, though the github editor is pretty intuitive if you choose to edit it there.",
+      "To submit an faq, follow the following steps:",
+      "1. Make a fork of the https://github.com/MinecraftCommands/commanderbot repositry",
+      "2. Edit the file `config/faq.json` to add your faq (see the other faqs for examples)",
+      "3. Commit your changes to your fork, with a helpful commit message",
+      "4. Create a pull request from your fork into the base repositry, with a helpful description of your changes",
+      "5. Notify Arcensoth in #meta"
+    ],
+    "tags": "meta",
+    "aliases": ["faq submission"]
   }
 }

--- a/config/faq.json
+++ b/config/faq.json
@@ -583,7 +583,7 @@
     "message": [
       "Our faq system is based off of submitting pull requests on github. If you want to submit one, you'll need a github account. You also probably want a basic understanding of how git works, though the github editor is pretty intuitive if you choose to edit it there.",
       "To submit an faq, follow the following steps:",
-      "1. Make a fork of the https://github.com/MinecraftCommands/commanderbot repositry",
+      "1. Make a fork of the https://github.com/MinecraftCommands/commanderbot repository",
       "2. Edit the file `config/faq.json` to add your faq (see the other faqs for examples)",
       "3. Commit your changes to your fork, with a helpful commit message",
       "4. Create a pull request from your fork into the base repositry, with a helpful description of your changes",


### PR DESCRIPTION
I've put this in a separate pull request to my other changes; I'm not sure if this is an faq we want or not.

- Added `faq submission`, which is a guide on how to submit faqs.

Perhaps this could just be a pin in #meta instead?